### PR TITLE
Add optional second button for controller

### DIFF
--- a/elden_pause.ini
+++ b/elden_pause.ini
@@ -5,40 +5,23 @@
 KeyboardButton=0x50
 # A specific mapped controller code.
 # Here is the full list of available codes:
-# A                                   0x5800
-# B                                   0x5801
-# X                                   0x5802
-# Y                                   0x5803
-# Right shoulder button               0x5804
-# Left shoulder button                0x5805
-# Left trigger                        0x5806
-# Right trigger                       0x5807
-# Directional pad up                  0x5810
-# Directional pad down                0x5811
-# Directional pad left                0x5812
-# Directional pad right               0x5813
-# START button                        0x5814
-# BACK button                         0x5815
-# Left thumbstick click               0x5816
-# Right thumbstick click              0x5817
-# Left thumbstick up                  0x5820
-# Left thumbstick down                0x5821
-# Left thumbstick right               0x5822
-# Left thumbstick left                0x5823
-# Left thumbstick up and left         0x5824
-# Left thumbstick up and right        0x5825
-# Left thumbstick down and right      0x5826
-# Left thumbstick down and left       0x5827
-# Right thumbstick up                 0x5830
-# Right thumbstick down               0x5831
-# Right thumbstick right              0x5832
-# Right thumbstick left               0x5833
-# Right thumbstick up and left        0x5834
-# Right thumbstick up and right       0x5835
-# Right thumbstick down and right     0x5836
-# Right thumbstick down and left      0x5837
-# "0x5814" by default
-ControllerButton=0x5814
+# A                                   0x1000
+# B                                   0x2000
+# X                                   0x4000
+# Y                                   0x8000
+# Left shoulder button                0x0100
+# Right shoulder button               0x0200
+# Directional pad up                  0x0001
+# Directional pad down                0x0002
+# Directional pad left                0x0004
+# Directional pad right               0x0008
+# START button                        0x0010
+# BACK button                         0x0020
+# Left thumbstick click               0x0040
+# Right thumbstick click              0x0080
+# DISABLED					   0xFFFF
+ControllerButton=0x0010 	# Default 0x0010
+ControllerButton2=0xFFFF	# Default 0xFFFF
 # Disable or enable the usage of controller code.
 # "true" by default
 ControllerEnabled=true

--- a/elden_pause/include/misc.h
+++ b/elden_pause/include/misc.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#define XINPUT_GAMEPAD_NONE 0xFFFF
+
 // Xinput specific
 namespace xinput
 {
@@ -14,7 +16,9 @@ namespace config
     const std::string KEY_CONTROLLER_ENABLED{ "ControllerEnabled" };
     const std::string KEY_KEYBOARD_BUTTON{ "KeyboardButton" };
     const std::string KEY_CONTROLLER_BUTTON{ "ControllerButton" };
+    const std::string KEY_CONTROLLER_BUTTON2{ "ControllerButton2" };
     std::string OPTION_CONTROLLER_ENABLED{ "true" }; // Disable or enable the usage of controller code. Enabled by default
     int32_t OPTION_KEYBOARD_BUTTON{ 0x50 }; // "P" button by default
-    int32_t OPTION_CONTROLLER_BUTTON{ VK_PAD_START }; // "Start" button by default
+    int32_t OPTION_CONTROLLER_BUTTON{ XINPUT_GAMEPAD_START }; // "Start" button by default
+    int32_t OPTION_CONTROLLER_BUTTON2{ XINPUT_GAMEPAD_NONE }; // Disabled by default
 }


### PR DESCRIPTION
Moved from `GetKeyStroke` to the `state.Gamepad.wButtons` object for convenience.